### PR TITLE
signup email must now be in string@string.string format

### DIFF
--- a/screens/LogInScreen.js
+++ b/screens/LogInScreen.js
@@ -43,20 +43,32 @@ export default class LogInScreen extends React.Component {
 
   signUpAsync = async () => {
     console.log("Clicked!");
-    API.createUser(this.state.email).then(dbResult => {
-      console.log("result", JSON.stringify(dbResult.data));
-      if (dbResult.data !== false) {
-        console.log(dbResult.data._id);
-        AsyncStorage.setItem("userToken", dbResult.data._id);
-        this.props.navigation.navigate("App");
-      } else {
-        console.log("There is an account with that email already");
-        this.setState({
-          errorMessage: "There is an account with that email already"
-        });
-      }
-    });
+    if (this.validateEmail(this.state.email)) {
+      API.createUser(this.state.email).then(dbResult => {
+        console.log("result", JSON.stringify(dbResult.data));
+        if (dbResult.data !== false) {
+          console.log(dbResult.data._id);
+          AsyncStorage.setItem("userToken", dbResult.data._id);
+          this.props.navigation.navigate("App");
+        } else {
+          console.log("There is an account with that email already");
+          this.setState({
+            errorMessage: "There is an account with that email already"
+          });
+        }
+      });
+    } else {
+      console.log("Not a valid email address");
+      this.setState({
+        errorMessage: "Please enter a valid email address"
+      });
+    }
   };
+
+  validateEmail = email => {
+    const pattern = /\S+@\S+\.\S+/;
+    return pattern.test(email);
+  }
 
   render() {
     return (


### PR DESCRIPTION
to have a more specific regex, it gets very long and is not recommended, and the only way to truly validate an email is to send an email that they can use to validate.  but at least now if the email isn't something@something.something, it will give a please enter a valid email address message.